### PR TITLE
feat: add xtdb support for postgres

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,12 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         com.taoensso/timbre {:mvn/version "6.5.0"}
         com.stuartsierra/component {:mvn/version "1.1.0"}
+        com.xtdb/xtdb-core {:mvn/version "1.24.0"}
+        com.xtdb/xtdb-jdbc {:mvn/version "1.24.0"}
         aero/aero {:mvn/version "1.1.6"}}
  :aliases {:dev {:extra-paths ["dev"]}
+           :pg {:extra-deps {org.postgresql/postgresql {:mvn/version "42.7.1"}}}
            :run {:main-opts ["-m" "com.emerauth.core"]
                  :exec-fn com.emerauth.core/-main}
            :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}}

--- a/dev/com/emerauth/dev_core.clj
+++ b/dev/com/emerauth/dev_core.clj
@@ -2,12 +2,14 @@
   (:require
    [com.emerauth.components.config :as config]
    [com.emerauth.components.logger :as logger]
+   [com.emerauth.components.db :as db]
    [com.stuartsierra.component :as component]))
 
 (def system-map
   (component/system-map
-   :config (config/new-config "config.dev.edn")
-   :logger (component/using (logger/new-logger) [:config])))
+   :config (config/new-config "config.example.edn")
+   :logger (component/using (logger/new-logger) [:config])
+   :db (component/using (db/new-db) [:config])))
 
 (comment
   (def system (atom nil))

--- a/resources/config.example.edn
+++ b/resources/config.example.edn
@@ -17,14 +17,12 @@
          :resources
          {:grpc {:anon ["HealthCheck" "SignUp" "SignIn"]}
           :http {:store {"/store/_/products" {:methods ["get" "post"]}}}}}}
- :db {:provider "postgres"
-      :connection {:schema "postgres"
-                   :username "emr-user"
-                   :password "emr-pass"
-                   :host "0.0.0.0"
+ :db {:provider :postgres
+      :connection {:host "localhost"
                    :port 5432
-                   :db-name "emerauth"
-                   :params {}}}
+                   :dbname "emerauth"
+                   :user "emer-user"
+                   :password "emer-pass"}}
  :auth {:providers {:otp {}}
         :jwt {:alg :hs256
               :ttl 3600}}

--- a/src/com/emerauth/components/db.clj
+++ b/src/com/emerauth/components/db.clj
@@ -1,0 +1,34 @@
+(ns com.emerauth.components.db
+  (:require
+    [xtdb.api :as xt]
+    [com.stuartsierra.component :as component]))
+
+(def specs 
+  {:postgres 
+   {:dialect-module 'xtdb.jdbc.psql/->dialect
+    :tx-log-module 'xtdb.jdbc/->tx-log
+    :document-store-module 'xtdb.jdbc/->document-store
+    :connection-pool :xtdb.jdbc/connection-pool}})
+
+(defrecord DB [config]
+  component/Lifecycle
+  (start [this]
+    (let [provider (get-in config [:db :provider])
+          spec (get specs provider)
+          node-spec {(:connection-pool spec) 
+                     {:dialect {:xtdb/module (:dialect-module spec)}
+                      :db-spec (get-in config [:db :connection])}
+                     :xtdb/tx-log 
+                     {:xtdb/module (:tx-log-module spec)
+                      :connection-pool (:connection-pool spec)}
+                     :xtdb/document-store 
+                     {:xtdb/module (:document-store-module spec)
+                      :connection-pool (:connection-pool spec)}}
+          node (xt/start-node node-spec)]
+      (println "XTDB started")
+      (assoc this :node node)))
+  (stop [this]
+    (.close (:node this))))
+
+(defn new-db []
+  (->DB {}))

--- a/src/com/emerauth/core.clj
+++ b/src/com/emerauth/core.clj
@@ -2,12 +2,14 @@
   (:require
    [com.emerauth.components.config :as config]
    [com.emerauth.components.logger :as logger]
+   [com.emerauth.components.db :as db]
    [com.stuartsierra.component :as component]))
 
 (def system-map
   (component/system-map
    :config (config/new-config "config.prod.edn")
-   :logger (component/using (logger/new-logger) [:config])))
+   :logger (component/using (logger/new-logger) [:config])
+   :db (component/using (db/new-db) [:config])))
 
 (defn -main
   "Emerauth's entry point."


### PR DESCRIPTION
# Start to use XTDB with JDBC

First implementation has been done with Postgres. The `config.example.edn` is changed for simpler specs.

Refer to https://github.com/emerauth/emerauth/issues/4