### PR TITLE
Fix: invalid BUG issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -49,6 +49,6 @@ body:
     attributes:
       label: Contribution Guidelines
       description: By submitting this issue, you affirm that you have read our [Contribution Guidelines](https://github.com/emerauth/emerauth/blob/main/CONTRIBUTING.md)
-    options:
-      - label: "I affirm that I did read Emerauth's Contribution Guidelines"
-        required: true
+      options:
+        - label: "I affirm that I did read Emerauth's Contribution Guidelines"
+          required: true


### PR DESCRIPTION
## What did I change?

The file `.github/ISSUE_TEMPLATE/BUG.yml` for problems with `options`.

## Related resources

Example of [body options](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#example-of-bodyi-options-must-be-unique-error)

## By creating this PR, I affirm that

- [x] If necessary, I've added tests that cover my changes.
- [x] I have run all tests and everything checks out.
- [x] If this patch brings user visible changes, I've discussed it in Emerauth's [Discussion Tab](https://github.com/emerauth/emerauth/discussions).
- [x] If this patch solves a problem, I've issued it in Emerauth's [Issues Tab](https://github.com/emerauth/emerauth/issues).
