### PR TITLE
Add new bug issue ticket directly to emerauth core project

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -3,6 +3,7 @@ description: Something is not working as expected
 title: Please summarize what is the problem
 assignees: ["J0sueTM", "lanjoni"]
 labels: ["bug", "triage"]
+projects: "emerauth/3"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## What did I change?

By adding a project definition to the BUG template, the issue ticket will automatically add our `emerauth core/3` project to it. 

## Related resources

## By creating this PR, I affirm that

- [x] If necessary, I've added tests that cover my changes.
- [x] I have run all tests and everything checks out.
- [x] If this patch brings user visible changes, I've discussed it in Emerauth's [Discussion Tab](https://github.com/emerauth/emerauth/discussions).
- [x] If this patch solves a problem, I've issued it in Emerauth's [Issues Tab](https://github.com/emerauth/emerauth/issues).
